### PR TITLE
fixed crash on saving (iOS4)

### DIFF
--- a/SDK/PocketAPIOperation.m
+++ b/SDK/PocketAPIOperation.m
@@ -404,7 +404,10 @@ NSString *PocketAPINameForHTTPMethod(PocketAPIHTTPMethod method){
 -(NSString *)pkt_URLEncodedFormString{
 	NSMutableArray *formPieces = [NSMutableArray arrayWithCapacity:self.allKeys.count];
 	for(NSString *key in self.allKeys){
-		NSString *value = [self objectForKey:key];
+		id value = [self objectForKey:key];
+		if ([value isKindOfClass:[NSNumber class]]) {
+			value = [value stringValue];
+		}
 		[formPieces addObject:[NSString stringWithFormat:@"%@=%@", [PocketAPIOperation encodeForURL:key], [PocketAPIOperation encodeForURL:value]]];
 	}
 	return [formPieces componentsJoinedByString:@"&"];


### PR DESCRIPTION
When `NSJSONSerialization` is not available (iOS4), HTTP body will be assembled by `pkt_URLEncodedFormString:`. The argument (`NSDictionary`) may be contain `NSNumber`, but this method does not transfer the type of it. This leads to crash in `[PocketAPIOperation encodeForURL:value]`.

I avoided this issue by transferring the type.


#### example of argument
```
key(NSString): time
value(NSNumber): 1361867614

key(NSString): consumer_key
value(NSString): *****

key(NSString): url
value(NSString): http://www.example.com

key(NSString): access_token
value(NSString): *****
```