### PR TITLE
Fix issue #7 - hanging operations after relogging

### DIFF
--- a/SDK/PocketAPIOperation.m
+++ b/SDK/PocketAPIOperation.m
@@ -279,6 +279,9 @@ NSString *PocketAPINameForHTTPMethod(PocketAPIHTTPMethod method){
 
 -(void)pocketAPILoggedIn:(PocketAPI *)api{
 	[[self.API operationQueue] addOperation:[[self copy] autorelease]];
+    // Copy of the current operation is scheduled on the operationQueue, so we have to
+    // mark the current operation as finished to let it be removed from the operationQueue.
+    [self pkt_connectionFinishedLoading];
 }
 
 -(void)pocketAPI:(PocketAPI *)api hadLoginError:(NSError *)theError{


### PR DESCRIPTION
I've fixed the issue #7 by marking an operation that triggered relogging as finished after the user successfully reauthorizes the application. A case when relogging is unsuccessful is already correctly implemented.