### PR TITLE
Login without Safari for iOS

### DIFF
--- a/SDK/PocketAPI.m
+++ b/SDK/PocketAPI.m
@@ -301,10 +301,7 @@ static PocketAPI *sSharedAPI = nil;
             PocketLoginViewController *loginViewController = [[[PocketLoginViewController alloc] initWithNibName:@"PocketLoginViewController" bundle:nil] autorelease];
             loginViewController.url = urlQuery[@"url"];
             loginViewController.modalTransitionStyle = UIModalPresentationPageSheet;
-            UIViewController *frontViewController = [UIApplication sharedApplication].keyWindow.rootViewController;
-            if (frontViewController.presentedViewController) {
-                frontViewController = frontViewController.presentedViewController;
-            }
+            UIViewController *frontViewController = [self topViewController];
              [frontViewController presentViewController:loginViewController animated:YES completion:nil];
             return YES;
         }
@@ -320,6 +317,25 @@ static PocketAPI *sSharedAPI = nil;
 	}
 	
 	return NO;
+}
+
+- (UIViewController*)topViewController {
+    return [self topViewControllerWithRootViewController:[UIApplication sharedApplication].keyWindow.rootViewController];
+}
+
+- (UIViewController*)topViewControllerWithRootViewController:(UIViewController*)rootViewController {
+    if ([rootViewController isKindOfClass:[UITabBarController class]]) {
+        UITabBarController* tabBarController = (UITabBarController*)rootViewController;
+        return [self topViewControllerWithRootViewController:tabBarController.selectedViewController];
+    } else if ([rootViewController isKindOfClass:[UINavigationController class]]) {
+        UINavigationController* navigationController = (UINavigationController*)rootViewController;
+        return [self topViewControllerWithRootViewController:navigationController.visibleViewController];
+    } else if (rootViewController.presentedViewController) {
+        UIViewController* presentedViewController = rootViewController.presentedViewController;
+        return [self topViewControllerWithRootViewController:presentedViewController];
+    } else {
+        return rootViewController;
+    }
 }
 
 -(NSUInteger)appID{

--- a/SDK/PocketAPI.m
+++ b/SDK/PocketAPI.m
@@ -28,6 +28,7 @@
 #import <dispatch/dispatch.h>
 #import <sys/sysctl.h>
 #import <CommonCrypto/CommonDigest.h>
+#import "PocketLoginViewController.h"
 
 #define POCKET_SDK_VERSION @"1.0.2"
 
@@ -296,7 +297,17 @@ static PocketAPI *sSharedAPI = nil;
 				[login _setRequestToken:requestToken];
 				[login _setReverseAuth:YES];
 			}
-		}
+		} else if ([[url path] isEqualToString:@"/login"] && [urlQuery objectForKey:@"url"]) {
+            PocketLoginViewController *loginViewController = [[[PocketLoginViewController alloc] initWithNibName:@"PocketLoginViewController" bundle:nil] autorelease];
+            loginViewController.url = urlQuery[@"url"];
+            loginViewController.modalTransitionStyle = UIModalPresentationPageSheet;
+            UIViewController *frontViewController = [UIApplication sharedApplication].keyWindow.rootViewController;
+            if (frontViewController.presentedViewController) {
+                frontViewController = frontViewController.presentedViewController;
+            }
+             [frontViewController presentViewController:loginViewController animated:YES completion:nil];
+            return YES;
+        }
 		
 		if(!login){
 			login = [self pkt_loadCurrentLoginFromDefaults];

--- a/SDK/PocketAPILogin.m
+++ b/SDK/PocketAPILogin.m
@@ -107,6 +107,7 @@ const NSString *PocketAPILoginFailedNotification = @"PocketAPILoginFailedNotific
 	return [NSURL URLWithString:[NSString stringWithFormat:@"%@:authorizationFinished", [self.API URLScheme]]];
 }
 
+
 -(void)fetchRequestToken{
 	[self loginDidStart];
 	
@@ -159,7 +160,14 @@ const NSString *PocketAPILoginFailedNotification = @"PocketAPILoginFailedNotific
 	if([PocketAPI hasPocketAppInstalled]){
 		authorizeURL = [NSURL URLWithString:[NSString stringWithFormat:@"pocket-oauth-v1:///authorize?request_token=%@&redirect_uri=%@",requestToken, encodedRedirectURLString]];
 	}else{
+#if TARGET_OS_IPHONE
+        NSString *loginWithWebBaseUrl = [NSString stringWithFormat:@"%@:///login/", [self.API URLScheme]];
+        NSString *urlParamStr = [PocketAPIOperation encodeForURL:[NSString stringWithFormat:@"https://getpocket.com/auth/authorize?request_token=%@&redirect_uri=%@",requestToken, encodedRedirectURLString]];
+        NSString *authUrlString = [NSString stringWithFormat:@"%@?url=%@", loginWithWebBaseUrl, urlParamStr];
+        authorizeURL = [NSURL URLWithString:authUrlString];
+#else
 		authorizeURL = [NSURL URLWithString:[NSString stringWithFormat:@"https://getpocket.com/auth/authorize?request_token=%@&redirect_uri=%@",requestToken, encodedRedirectURLString]];
+#endif
 	}
 	
 	[self openURL:authorizeURL];

--- a/SDK/PocketLoginViewController.h
+++ b/SDK/PocketLoginViewController.h
@@ -1,0 +1,15 @@
+//
+//  PocketLoginViewController.h
+//  iOS Test App
+//
+//  Created by Shuichi Asai on 2014/02/06.
+//  Copyright (c) 2014年 Read It Later, Inc. All rights reserved.
+//
+
+#import <UIKit/UIKit.h>
+
+@interface PocketLoginViewController : UIViewController
+@property (retain, nonatomic) IBOutlet UIWebView *webView;
+@property (retain, nonatomic) NSString *url;
+- (IBAction)cancelClicked:(id)sender;
+@end

--- a/SDK/PocketLoginViewController.m
+++ b/SDK/PocketLoginViewController.m
@@ -1,0 +1,70 @@
+//
+//  PocketLoginViewController.m
+//  iOS Test App
+//
+//  Created by Shuichi Asai on 2014/02/06.
+//  Copyright (c) 2014年 Read It Later, Inc. All rights reserved.
+//
+
+#import "PocketLoginViewController.h"
+#import "PocketAPI.h"
+
+@interface PocketLoginViewController ()<UIWebViewDelegate>
+
+@end
+
+@implementation PocketLoginViewController
+
+- (id)initWithNibName:(NSString *)nibNameOrNil bundle:(NSBundle *)nibBundleOrNil
+{
+    self = [super initWithNibName:nibNameOrNil bundle:nibBundleOrNil];
+    if (self) {
+        // Custom initialization
+    }
+    return self;
+}
+
+- (void)viewDidLoad
+{
+    [super viewDidLoad];
+    // Do any additional setup after loading the view from its nib.
+    self.webView.delegate = self;
+    [self.webView loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:self.url]]];
+}
+
+- (void)didReceiveMemoryWarning
+{
+    [super didReceiveMemoryWarning];
+    // Dispose of any resources that can be recreated.
+}
+
+- (void)dealloc {
+    [_webView release];
+    [_url release];
+    [super dealloc];
+}
+- (IBAction)cancelClicked:(id)sender {
+    [self dismissViewControllerAnimated:YES completion:nil];
+}
+
+#pragma mark -- UIWebViewDelegate
+- (void)webView:(UIWebView *)webView didFailLoadWithError:(NSError *)error
+{
+}
+- (BOOL)webView:(UIWebView *)webView shouldStartLoadWithRequest:(NSURLRequest *)request navigationType:(UIWebViewNavigationType)navigationType
+{
+    if ([request.URL.absoluteString hasPrefix:[[PocketAPI sharedAPI] URLScheme]]) {
+        [UIApplication sharedApplication].networkActivityIndicatorVisible = NO;
+        [self dismissViewControllerAnimated:NO completion:nil];
+    }
+    return YES;
+}
+- (void)webViewDidFinishLoad:(UIWebView *)webView
+{
+    [UIApplication sharedApplication].networkActivityIndicatorVisible = NO;
+}
+- (void)webViewDidStartLoad:(UIWebView *)webView
+{
+    [UIApplication sharedApplication].networkActivityIndicatorVisible = YES;
+}
+@end

--- a/SDK/PocketLoginViewController.m
+++ b/SDK/PocketLoginViewController.m
@@ -55,7 +55,7 @@
 {
     if ([request.URL.absoluteString hasPrefix:[[PocketAPI sharedAPI] URLScheme]]) {
         [UIApplication sharedApplication].networkActivityIndicatorVisible = NO;
-        [self dismissViewControllerAnimated:NO completion:nil];
+        [self dismissViewControllerAnimated:YES completion:nil];
     }
     return YES;
 }

--- a/SDK/PocketLoginViewController.xib
+++ b/SDK/PocketLoginViewController.xib
@@ -1,0 +1,54 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="4514" systemVersion="13B42" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES">
+    <dependencies>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="3747"/>
+    </dependencies>
+    <objects>
+        <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner" customClass="PocketLoginViewController">
+            <connections>
+                <outlet property="view" destination="1" id="3"/>
+                <outlet property="webView" destination="Lq1-H9-cZ5" id="Qnp-cV-LS7"/>
+            </connections>
+        </placeholder>
+        <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
+        <view contentMode="scaleToFill" id="1">
+            <rect key="frame" x="0.0" y="0.0" width="320" height="568"/>
+            <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+            <subviews>
+                <navigationBar contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="RRo-L5-MD2">
+                    <rect key="frame" x="0.0" y="17" width="320" height="44"/>
+                    <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMaxY="YES"/>
+                    <constraints>
+                        <constraint firstAttribute="height" constant="44" id="U26-G4-bXG"/>
+                    </constraints>
+                    <items>
+                        <navigationItem title="Login to Pocket" id="rab-OU-fa5">
+                            <barButtonItem key="leftBarButtonItem" title="Cancel" id="4hi-cZ-kh4">
+                                <connections>
+                                    <action selector="cancelClicked:" destination="-1" id="Xth-7X-ZLK"/>
+                                </connections>
+                            </barButtonItem>
+                        </navigationItem>
+                    </items>
+                </navigationBar>
+                <webView contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Lq1-H9-cZ5">
+                    <rect key="frame" x="0.0" y="61" width="320" height="507"/>
+                    <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                    <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="calibratedRGB"/>
+                </webView>
+            </subviews>
+            <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="calibratedWhite"/>
+            <constraints>
+                <constraint firstItem="Lq1-H9-cZ5" firstAttribute="leading" secondItem="1" secondAttribute="leading" id="IzB-nf-8nO"/>
+                <constraint firstItem="RRo-L5-MD2" firstAttribute="leading" secondItem="1" secondAttribute="leading" id="Vb7-Ab-8MB"/>
+                <constraint firstAttribute="trailing" secondItem="RRo-L5-MD2" secondAttribute="trailing" id="fKD-v2-fJV"/>
+                <constraint firstAttribute="trailing" secondItem="Lq1-H9-cZ5" secondAttribute="trailing" id="ffM-AJ-4aB"/>
+                <constraint firstAttribute="bottom" secondItem="Lq1-H9-cZ5" secondAttribute="bottom" id="gqH-sT-PrN"/>
+                <constraint firstItem="RRo-L5-MD2" firstAttribute="top" secondItem="1" secondAttribute="top" constant="17" id="nJ8-lo-C0t"/>
+                <constraint firstItem="Lq1-H9-cZ5" firstAttribute="top" secondItem="RRo-L5-MD2" secondAttribute="bottom" id="s5C-uN-Dor"/>
+            </constraints>
+            <simulatedStatusBarMetrics key="simulatedStatusBarMetrics"/>
+            <simulatedScreenMetrics key="simulatedDestinationMetrics" type="retina4"/>
+        </view>
+    </objects>
+</document>


### PR DESCRIPTION
I rejected my iPhone app using Pocket API by Apple, because of following reason today.
**
We found the following issues with the user interface of your app: The app opens a web page in mobile Safari for logging in, then returns the user to the app. The user should be able log in without opening Safari first.
**
So I had made login api not to use safari. I hope you like this.