### PR TITLE
Fix -Wundef warnings

### DIFF
--- a/Examples/MacApp/Mac Test App.xcodeproj/project.pbxproj
+++ b/Examples/MacApp/Mac Test App.xcodeproj/project.pbxproj
@@ -446,6 +446,7 @@
 				GCC_PREFIX_HEADER = "PocketSDK-Prefix.pch";
 				INFOPLIST_FILE = "PocketSDK-Info.plist";
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				WARNING_CFLAGS = "-Wundef";
 				WRAPPER_EXTENSION = app;
 			};
 			name = Debug;
@@ -457,6 +458,7 @@
 				GCC_PREFIX_HEADER = "PocketSDK-Prefix.pch";
 				INFOPLIST_FILE = "PocketSDK-Info.plist";
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				WARNING_CFLAGS = "-Wundef";
 				WRAPPER_EXTENSION = app;
 			};
 			name = Release;

--- a/Examples/iOSApp/iOS Test App.xcodeproj/project.pbxproj
+++ b/Examples/iOSApp/iOS Test App.xcodeproj/project.pbxproj
@@ -301,6 +301,7 @@
 				INFOPLIST_FILE = "PocketSDK-Info.plist";
 				IPHONEOS_DEPLOYMENT_TARGET = 4.3;
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				WARNING_CFLAGS = "-Wundef";
 				WRAPPER_EXTENSION = app;
 			};
 			name = Debug;
@@ -316,6 +317,7 @@
 				IPHONEOS_DEPLOYMENT_TARGET = 4.3;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				"PROVISIONING_PROFILE[sdk=iphoneos*]" = "";
+				WARNING_CFLAGS = "-Wundef";
 				WRAPPER_EXTENSION = app;
 			};
 			name = Release;

--- a/SDK/PocketAPI.m
+++ b/SDK/PocketAPI.m
@@ -178,7 +178,7 @@ static PocketAPI *sSharedAPI = nil;
 	}
 	
 	// if on a Mac, and this user was logged in with a pre-1.0.2 SDK, attempt to migrate the keychain values if the token/digest pair matches
-#if !DEBUG && TARGET_OS_MAC && !TARGET_OS_IPHONE && !TARGET_IPHONE_SIMULATOR
+#if !(defined(DEBUG) && DEBUG) && TARGET_OS_MAC && !TARGET_OS_IPHONE && !TARGET_IPHONE_SIMULATOR
 	if(![self pkt_getToken]){ // if we don't already have a token
 		NSString *existingHash = [self pkt_getKeychainValueForKey:@"tokenDigest" serviceName:@"PocketAPI"];
 		if(existingHash){ // ...but we do have an unmigrated token
@@ -226,7 +226,7 @@ static PocketAPI *sSharedAPI = nil;
 	[URLScheme release];
 	URLScheme = aURLScheme;
 	
-#if DEBUG
+#if defined(DEBUG) && DEBUG
 	// check to make sure 
 	BOOL foundURLScheme = NO;
 	NSDictionary *infoDict = [[NSBundle mainBundle] infoDictionary];
@@ -697,13 +697,13 @@ static PocketAPI *sSharedAPI = nil;
 
 -(void)pkt_setKeychainValue:(id)value forKey:(NSString *)key serviceName:(NSString *)serviceName{
 	if(value){
-#if TARGET_IPHONE_SIMULATOR || (DEBUG && !TARGET_OS_IPHONE && TARGET_OS_MAC)
+#if TARGET_IPHONE_SIMULATOR || (defined(DEBUG) && DEBUG && !TARGET_OS_IPHONE && TARGET_OS_MAC)
 		[[NSUserDefaults standardUserDefaults] setObject:value forKey:[NSString stringWithFormat:@"%@.%@", serviceName, key]];
 #else
 		[PocketAPIKeychainUtils storeUsername:key andPassword:value forServiceName:serviceName updateExisting:YES error:nil];
 #endif
 	}else{
-#if TARGET_IPHONE_SIMULATOR || (DEBUG && !TARGET_OS_IPHONE && TARGET_OS_MAC)
+#if TARGET_IPHONE_SIMULATOR || (defined(DEBUG) && DEBUG && !TARGET_OS_IPHONE && TARGET_OS_MAC)
 		[[NSUserDefaults standardUserDefaults] removeObjectForKey:[NSString stringWithFormat:@"%@.%@", serviceName, key]];
 #else
 		[PocketAPIKeychainUtils deleteItemForUsername:key andServiceName:serviceName error:nil];
@@ -712,7 +712,7 @@ static PocketAPI *sSharedAPI = nil;
 }
 
 -(id)pkt_getKeychainValueForKey:(NSString *)key serviceName:(NSString *)serviceName{
-#if TARGET_IPHONE_SIMULATOR || (DEBUG && !TARGET_OS_IPHONE && TARGET_OS_MAC)
+#if TARGET_IPHONE_SIMULATOR || (defined(DEBUG) && DEBUG && !TARGET_OS_IPHONE && TARGET_OS_MAC)
 	return [[NSUserDefaults standardUserDefaults] objectForKey:[NSString stringWithFormat:@"%@.%@", serviceName, key]];
 #else
 	return [PocketAPIKeychainUtils getPasswordForUsername:key andServiceName:serviceName error:nil];

--- a/SDK/PocketAPIKeychainUtils.m
+++ b/SDK/PocketAPIKeychainUtils.m
@@ -32,7 +32,7 @@
 
 static NSString *PocketAPIKeychainUtilsErrorDomain = @"PocketAPIKeychainUtilsErrorDomain";
 
-#if __IPHONE_OS_VERSION_MIN_REQUIRED < 30000 && TARGET_IPHONE_SIMULATOR
+#if defined(__IPHONE_OS_VERSION_MIN_REQUIRED) && __IPHONE_OS_VERSION_MIN_REQUIRED < 30000 && TARGET_IPHONE_SIMULATOR
 @interface PocketAPIKeychainUtils (PrivateMethods)
 + (SecKeychainItemRef) getKeychainItemReferenceForUsername: (NSString *) username andServiceName: (NSString *) serviceName error: (NSError **) error;
 @end
@@ -40,7 +40,7 @@ static NSString *PocketAPIKeychainUtilsErrorDomain = @"PocketAPIKeychainUtilsErr
 
 @implementation PocketAPIKeychainUtils
 
-#if __IPHONE_OS_VERSION_MIN_REQUIRED < 30000 && TARGET_IPHONE_SIMULATOR
+#if defined(__IPHONE_OS_VERSION_MIN_REQUIRED) && __IPHONE_OS_VERSION_MIN_REQUIRED < 30000 && TARGET_IPHONE_SIMULATOR
 
 + (NSString *) getPasswordForUsername: (NSString *) username andServiceName: (NSString *) serviceName error: (NSError **) error {
 	if (!username || !serviceName) {


### PR DESCRIPTION
Vanilla iOS projects define `DEBUG` to be 1 in the Debug build configuration, and don't define `DEBUG` at all in the Release build configuration. That means that if you make a release build `DEBUG` is implicitly 0, but if you turn on the -Wundef warning flag you'll get warnings about this implicit value.

![screen shot 2015-02-24 at 11 26 56 am](https://cloud.githubusercontent.com/assets/522951/6358676/30fe9a12-bc22-11e4-9797-96b37560d6fb.png)

This pull request explicitly makes sure both that `DEBUG` is defined and that its value evaluates to true. It also fixes another warning related to using an iOS-only macro in the Mac project.

This mirrors a change I made to our `FLAnimatedImage` project at https://github.com/Flipboard/FLAnimatedImage/pull/66.