### PR TITLE
iOS 9 Pocket app auth minor issue fix

### DIFF
--- a/Examples/iOSApp/PocketSDK-Info.plist
+++ b/Examples/iOSApp/PocketSDK-Info.plist
@@ -22,6 +22,10 @@
 	<string>????</string>
 	<key>CFBundleVersion</key>
 	<string>1.0</string>
+	<key>LSApplicationQueriesSchemes</key>
+	<array>
+		<string>pocket-oauth-v1</string>
+	</array>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
 	<key>UIRequiredDeviceCapabilities</key>

--- a/Examples/iOSApp/iOS Test App.xcodeproj/project.pbxproj
+++ b/Examples/iOSApp/iOS Test App.xcodeproj/project.pbxproj
@@ -295,6 +295,7 @@
 		AA37FB13157570ED00A63400 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				ENABLE_BITCODE = NO;
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
 				GCC_PREFIX_HEADER = "PocketSDK-Prefix.pch";
 				GCC_VERSION = com.apple.compilers.llvm.clang.1_0;
@@ -310,6 +311,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Distribution";
+				ENABLE_BITCODE = NO;
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
 				GCC_PREFIX_HEADER = "PocketSDK-Prefix.pch";
 				GCC_VERSION = com.apple.compilers.llvm.clang.1_0;

--- a/Examples/iOSApp/iOS Test App.xcodeproj/project.pbxproj
+++ b/Examples/iOSApp/iOS Test App.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		63637AC91BECB19700E1955A /* PocketAPIApplicationStateWatcher.m in Sources */ = {isa = PBXBuildFile; fileRef = 63637AC81BECB19700E1955A /* PocketAPIApplicationStateWatcher.m */; };
 		9D50B34B1A4EEEBA00856233 /* PocketRSSParser.m in Sources */ = {isa = PBXBuildFile; fileRef = 9D50B34A1A4EEEBA00856233 /* PocketRSSParser.m */; settings = {COMPILER_FLAGS = "-fobjc-arc"; }; };
 		AA0FCA8B1648A8FB005AE7DA /* Default-568h@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = AA0FCA8A1648A8FB005AE7DA /* Default-568h@2x.png */; };
 		AA37FAF9157570ED00A63400 /* UIKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = AA37FAF8157570ED00A63400 /* UIKit.framework */; };
@@ -27,6 +28,8 @@
 
 /* Begin PBXFileReference section */
 		456D82AF15E46395002779D3 /* PocketAPI+NSOperation.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "PocketAPI+NSOperation.h"; sourceTree = "<group>"; };
+		63637AC71BECB19700E1955A /* PocketAPIApplicationStateWatcher.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = PocketAPIApplicationStateWatcher.h; sourceTree = "<group>"; };
+		63637AC81BECB19700E1955A /* PocketAPIApplicationStateWatcher.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = PocketAPIApplicationStateWatcher.m; sourceTree = "<group>"; };
 		9D50B3491A4EEEBA00856233 /* PocketRSSParser.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = PocketRSSParser.h; sourceTree = "<group>"; };
 		9D50B34A1A4EEEBA00856233 /* PocketRSSParser.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = PocketRSSParser.m; sourceTree = "<group>"; };
 		AA0FCA8A1648A8FB005AE7DA /* Default-568h@2x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "Default-568h@2x.png"; sourceTree = "<group>"; };
@@ -138,6 +141,8 @@
 				AA37FB3315769D5700A63400 /* PocketAPI.h */,
 				456D82AF15E46395002779D3 /* PocketAPI+NSOperation.h */,
 				AA37FB3415769D5700A63400 /* PocketAPI.m */,
+				63637AC71BECB19700E1955A /* PocketAPIApplicationStateWatcher.h */,
+				63637AC81BECB19700E1955A /* PocketAPIApplicationStateWatcher.m */,
 				AA9685EF15BDDED900E9F7F1 /* PocketAPILogin.h */,
 				AA9685F015BDDED900E9F7F1 /* PocketAPILogin.m */,
 				AA37FB3515769D5700A63400 /* PocketAPIOperation.h */,
@@ -223,6 +228,7 @@
 				9D50B34B1A4EEEBA00856233 /* PocketRSSParser.m in Sources */,
 				AA37FB4415769E8200A63400 /* main.m in Sources */,
 				AA9685F115BDDED900E9F7F1 /* PocketAPILogin.m in Sources */,
+				63637AC91BECB19700E1955A /* PocketAPIApplicationStateWatcher.m in Sources */,
 				AAD8655815E807BF001F0C0E /* PocketRSSViewController.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/SDK/PocketAPIApplicationStateWatcher.h
+++ b/SDK/PocketAPIApplicationStateWatcher.h
@@ -1,0 +1,23 @@
+//
+//  PocketAPIApplicationStateWatcher.h
+//
+//  Created by Alexander Smarus on 05.11.2015.
+//
+
+#import <Foundation/Foundation.h>
+
+@class PocketAPIApplicationStateWatcher;
+
+@protocol PocketAPIApplicationStateWatcherDelegate <NSObject>
+
+- (void)applicationStateWatcher:(PocketAPIApplicationStateWatcher *)watcher didDetectTransitionSuccess:(BOOL)success;
+
+@end
+
+@interface PocketAPIApplicationStateWatcher : NSObject
+
+@property (nonatomic, assign) id<PocketAPIApplicationStateWatcherDelegate> delegate;
+
+- (void)expectBackgroundMode;
+
+@end

--- a/SDK/PocketAPIApplicationStateWatcher.m
+++ b/SDK/PocketAPIApplicationStateWatcher.m
@@ -1,0 +1,79 @@
+//
+//  PocketAPIApplicationStateWatcher.m
+//
+//  Created by Alexander Smarus on 05.11.2015.
+//
+//  When app tries to open other app with openURL: on iOS 9
+//  the system asks user to confirm the action.
+//  And there is no proper way to detect when user cancels request.
+//
+//  This solution is based on specific sequence of application state transitions
+//  which are only have place when iOS shows confiramtion
+//  and then not opens requested app.
+//
+//  UIApplicationDidEnterBackgroundNotification means that we
+//  successfully got switched to Pocket app.
+//  UIApplicationDidBecomeActiveNotification means that
+//  user have selected one of the options in confirmation alert.
+//  We should expect UIApplicationDidEnterBackgroundNotification
+//  in a moment as sign of success. No notification means failure.
+
+
+#import "PocketAPIApplicationStateWatcher.h"
+
+typedef NS_ENUM(NSUInteger, PocketAPIApplicationStateWatcherState) {
+    PocketAPIApplicationStateWatcherStateInitial,
+    PocketAPIApplicationStateWatcherStateSuccess,
+    PocketAPIApplicationStateWatcherStateFailure
+};
+
+@interface PocketAPIApplicationStateWatcher ()
+
+@property (nonatomic, assign) BOOL didEnterBackground;
+
+@end
+
+
+@implementation PocketAPIApplicationStateWatcher
+
+- (void)expectBackgroundMode {
+    [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(applicationDidEnterBackground:) name:UIApplicationDidEnterBackgroundNotification object:nil];
+    [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(applicationDidBecomeActive:) name:UIApplicationDidBecomeActiveNotification object:nil];
+}
+
+- (void)dealloc {
+    [self cancelScheduledFail];
+    [[NSNotificationCenter defaultCenter] removeObserver:self];
+    [super dealloc];
+}
+
+- (void)applicationDidEnterBackground:(NSNotification *)notification {
+    self.didEnterBackground = YES;
+    [self cancelScheduledFail];
+    [self reportSuccess];
+}
+
+
+- (void)applicationDidBecomeActive:(NSNotification *)notification {
+    if (!self.didEnterBackground) {
+        [self reportFailAfterDelay];
+    }
+}
+
+- (void)reportFailAfterDelay {
+    [self performSelector:@selector(reportFail) withObject:nil afterDelay:0.3];
+}
+
+- (void)cancelScheduledFail {
+    [NSObject cancelPreviousPerformRequestsWithTarget:self selector:@selector(reportFailAfterDelay) object:nil];
+}
+
+- (void)reportFail {
+    [self.delegate applicationStateWatcher:self didDetectTransitionSuccess:NO];
+}
+
+- (void)reportSuccess {
+    [self.delegate applicationStateWatcher:self didDetectTransitionSuccess:YES];
+}
+
+@end

--- a/SDK/PocketAPILogin.h
+++ b/SDK/PocketAPILogin.h
@@ -8,8 +8,9 @@
 
 #import <Foundation/Foundation.h>
 #import "PocketAPI.h"
+#import "PocketAPIApplicationStateWatcher.h"
 
-@interface PocketAPILogin : NSObject <NSCoding, PocketAPIDelegate> {
+@interface PocketAPILogin : NSObject <NSCoding, PocketAPIDelegate, PocketAPIApplicationStateWatcherDelegate> {
 	PocketAPI *API;
 	
 	NSString *uuid; // unique ID for the login process
@@ -18,7 +19,8 @@
 	NSString *accessToken;
 	
 	NSOperationQueue *operationQueue;
-	
+    PocketAPIApplicationStateWatcher *appStateWatcher;
+    
 	id<PocketAPIDelegate> delegate;
 	
 	BOOL didStart;

--- a/SDK/PocketAPITypes.h
+++ b/SDK/PocketAPITypes.h
@@ -70,7 +70,10 @@ typedef enum {
 	PocketAPIErrorSignupEmailTaken = 105,
 
 	// Server Problems
-	PocketAPIErrorServerMaintenance = 199
+	PocketAPIErrorServerMaintenance = 199,
+    
+    // Other
+    PocketAPIErrorInterruptedByUser = 300,
 } PocketAPIError;
 
 extern const NSString *PocketAPIErrorDomain;


### PR DESCRIPTION
Hello,

When app tries to open other app with `-[UIApplication openURL:]` on iOS 9 first time the system asks user to confirm the action. And there is no proper way to detect when user cancels request. Currently SDK just assumes everything is OK and waits forever.

iOS asks for confirmation on every login attempt until it allowed once. Minor issue as for me, but for better user experience we should handle this in some way.

This solution is based on specific sequence of application state transitions which are only have place when iOS shows confirmation and then not opens Pocket app.

`UIApplicationDidEnterBackgroundNotification` means that we successfully got switched to Pocket app.
`UIApplicationDidBecomeActiveNotification` means that user has selected one of the options in confirmation alert. We should expect `UIApplicationDidEnterBackgroundNotification` in a moment as sign of success. No notification means failure.

I've disabled bitcode and added Pocket app scheme to project plist to make sample app build'n'run.
The actual issue fix is in `5e1c6ec`.
