### PR TITLE
Add import for build with framework

### DIFF
--- a/SDK/PocketAPI+NSOperation.h
+++ b/SDK/PocketAPI+NSOperation.h
@@ -26,6 +26,8 @@
 // If you don't need tight control over network requests, just use the simple API.
 // Note: May not behave predictably if recoverable errors are encountered.
 
+#import "PocketAPI.h"
+
 @interface PocketAPI (NSOperations)
 
 -(NSOperation *)saveOperationWithURL:(NSURL *)url


### PR DESCRIPTION
Hi Pocket

This pull-request fixes that PocketAPI cannot be built with Cocoapods when use "use_frameworks!"

Podfile

```
platform :ios, '8.0'
use_frameworks!

target 'pockettest' do
  pod 'PocketAPI'
end
```

AppDelegate.swift

```swift
import PocketAPI
```

And I got error.

![2016-01-18 14 10 06](https://cloud.githubusercontent.com/assets/5355966/12383776/5196a94a-bded-11e5-8d6a-a8ceeecb629f.png)

The problem is the order of #import in PocketAPI-umbrella.h.
Cocoapods generates PocketAPI-umbrella.h automatically.

```objc
#import <UIKit/UIKit.h>

#import "PocketAPI+NSOperation.h"
#import "PocketAPI.h"
#import "PocketAPIKeychainUtils.h"
#import "PocketAPILogin.h"
#import "PocketAPIOperation.h"
#import "PocketAPITypes.h"

FOUNDATION_EXPORT double PocketAPIVersionNumber;
FOUNDATION_EXPORT const unsigned char PocketAPIVersionString[];
```

"PocketAPI+NSOperation.h" doesn't include PocketAPI.
I don't know this is the right way to integrate with Cocoapods but this fixes the problem.
Thanks.
