### PR TITLE
Fix warnings in Xcode 9

### DIFF
--- a/SDK/PocketAPILogin.m
+++ b/SDK/PocketAPILogin.m
@@ -25,11 +25,11 @@
 #import "PocketAPIExtensionSafe.h"
 #import "PocketAPIOperation.h"
 
-const NSString *PocketAPIErrorDomain = @"PocketAPIErrorDomain";
+NSString * const PocketAPIErrorDomain = @"PocketAPIErrorDomain";
 
-const NSString *PocketAPILoginStartedNotification = @"PocketAPILoginStartedNotification";
-const NSString *PocketAPILoginFinishedNotification = @"PocketAPILoginFinishedNotification";
-const NSString *PocketAPILoginFailedNotification = @"PocketAPILoginFailedNotification";
+NSString * const PocketAPILoginStartedNotification = @"PocketAPILoginStartedNotification";
+NSString * const PocketAPILoginFinishedNotification = @"PocketAPILoginFinishedNotification";
+NSString * const PocketAPILoginFailedNotification = @"PocketAPILoginFailedNotification";
 
 @interface PocketAPIOperation (Private)
 

--- a/SDK/PocketAPITypes.h
+++ b/SDK/PocketAPITypes.h
@@ -88,7 +88,7 @@ typedef enum {
 	PocketAPIErrorServerMaintenance = 199
 } PocketAPIError;
 
-extern const NSString *PocketAPIErrorDomain;
+extern NSString * const PocketAPIErrorDomain;
 
-extern const NSString *PocketAPILoginStartedNotification;
-extern const NSString *PocketAPILoginFinishedNotification;
+extern NSString * const PocketAPILoginStartedNotification;
+extern NSString * const PocketAPILoginFinishedNotification;


### PR DESCRIPTION
These were pointers to consts which can be modified at runtime by changing the pointer.
I've modified them to be consts to pointers which are static once compiled.

This warning would appear when attempting to use the const in: `[NSNotificationCenter addObserver:selector:name:object:]`

These warnings do not appear in the test app because the test app explicitly casts these consts to `(NSString *)` at the callsite.

For more information see here: https://stackoverflow.com/questions/6828831/sending-const-nsstring-to-parameter-of-type-nsstring-discards-qualifier